### PR TITLE
Add pytest for ai-server

### DIFF
--- a/test/test_cli_mode.py
+++ b/test/test_cli_mode.py
@@ -2,10 +2,8 @@ import pytest
 import os
 import subprocess
 from unittest.mock import patch, MagicMock
-import sys
 
 os.environ.setdefault('REDIS_URL', 'redis://localhost:6379')
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..'))
 
 from ai_server.server import (
     chat_with_llamacpp,

--- a/test/test_cli_mode.py
+++ b/test/test_cli_mode.py
@@ -1,0 +1,150 @@
+import pytest
+import os
+import subprocess
+from unittest.mock import patch, MagicMock
+import sys
+
+os.environ.setdefault('REDIS_URL', 'redis://localhost:6379')
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..'))
+
+from ai_server.server import (
+    chat_with_llamacpp,
+    chat_with_model
+)
+
+# Test models
+TEST_LLAMACPP_MODEL = 'DeepSeek-V3-0324-UD-IQ2_XXS'
+TEST_OLLAMA_MODEL = 'deepseek-coder-v2:latest'
+
+
+class TestLlamaCppCLI:
+    """Test llama.cpp CLI execution."""
+    
+    @patch('ai_server.server.subprocess.run')
+    @patch('ai_server.server.resolve_model_path')
+    def test_chat_with_llamacpp_success(self, mock_resolve, mock_subprocess):
+        """Test successful CLI chat with llama.cpp."""
+        model_path = f'/data1/GGUF/{TEST_LLAMACPP_MODEL}/{TEST_LLAMACPP_MODEL}.gguf'
+        mock_resolve.return_value = model_path
+        
+        mock_result = MagicMock()
+        mock_result.stdout = b'I can help you with DeepSeek V3.'
+        mock_subprocess.return_value = mock_result
+        
+        result = chat_with_llamacpp(TEST_LLAMACPP_MODEL, 'Hello, can you help me code?')
+        
+        assert result == "I can help you with DeepSeek V3."
+        mock_resolve.assert_called_once_with(TEST_LLAMACPP_MODEL)
+        
+        # Verify correct CLI command structure
+        args, kwargs = mock_subprocess.call_args
+        cmd = args[0]
+        assert '/data1/llama.cpp/bin/llama-cli' in cmd
+        assert '-m' in cmd and model_path in cmd
+        assert '--n-gpu-layers' in cmd and '40' in cmd
+        assert '--single-turn' in cmd
+    
+    @patch('ai_server.server.resolve_model_path')
+    def test_chat_with_llamacpp_model_not_found(self, mock_resolve):
+        """Test CLI chat when model is not found."""
+        mock_resolve.return_value = None
+        
+        with pytest.raises(ValueError, match="Model not found: nonexistent-model"):
+            chat_with_llamacpp('nonexistent-model', 'Hello')
+    
+    @patch('ai_server.server.subprocess.run')
+    @patch('ai_server.server.resolve_model_path')
+    def test_chat_with_llamacpp_subprocess_error(self, mock_resolve, mock_subprocess):
+        """Test CLI chat when subprocess fails."""
+        mock_resolve.return_value = f'/data1/GGUF/{TEST_LLAMACPP_MODEL}/{TEST_LLAMACPP_MODEL}.gguf'
+        
+        error = subprocess.CalledProcessError(1, 'cmd')
+        error.stderr = b'CUDA out of memory'
+        mock_subprocess.side_effect = error
+        
+        with pytest.raises(Exception, match=f"Llama.cpp failed for {TEST_LLAMACPP_MODEL}: CUDA out of memory"):
+            chat_with_llamacpp(TEST_LLAMACPP_MODEL, 'Hello')
+
+
+class TestCLIModeRouting:
+    """Test CLI mode routing and fallback logic."""
+    
+    @patch('ai_server.server.chat_with_llamacpp')
+    @patch('ai_server.server.is_llamacpp_available')
+    def test_cli_mode_uses_llamacpp_when_available(self, mock_available, mock_chat_llamacpp):
+        """Test CLI mode routes to llama.cpp when model is available."""
+        mock_available.return_value = True
+        mock_chat_llamacpp.return_value = "CLI response from DeepSeek V3"
+        
+        result = chat_with_model(TEST_LLAMACPP_MODEL, 'Write a function', llama_mode='cli')
+        
+        assert result == "CLI response from DeepSeek V3"
+        mock_available.assert_called_once_with(TEST_LLAMACPP_MODEL)
+        mock_chat_llamacpp.assert_called_once_with(TEST_LLAMACPP_MODEL, 'Write a function')
+    
+    @patch('ai_server.server.chat_with_ollama')
+    @patch('ai_server.server.is_llamacpp_available')
+    def test_cli_mode_fallback_to_ollama_when_unavailable(self, mock_available, mock_chat_ollama):
+        """Test CLI mode falls back to ollama when model not available in llama.cpp."""
+        mock_available.return_value = False
+        mock_chat_ollama.return_value = "Ollama response from DeepSeek Coder"
+        
+        result = chat_with_model(TEST_OLLAMA_MODEL, 'Help with coding', llama_mode='cli')
+        
+        assert result == "Ollama response from DeepSeek Coder"
+        mock_available.assert_called_once_with(TEST_OLLAMA_MODEL)
+        mock_chat_ollama.assert_called_once_with(TEST_OLLAMA_MODEL, 'Help with coding')
+    
+    @patch('ai_server.server.chat_with_llamacpp')
+    @patch('ai_server.server.is_llamacpp_available')
+    def test_default_mode_is_cli(self, mock_available, mock_chat_llamacpp):
+        """Test that default mode is CLI when no llama_mode specified."""
+        mock_available.return_value = True
+        mock_chat_llamacpp.return_value = "Default CLI mode response"
+        
+        result = chat_with_model(TEST_LLAMACPP_MODEL, 'Help me')  # No llama_mode specified
+        
+        assert result == "Default CLI mode response"
+        mock_available.assert_called_once_with(TEST_LLAMACPP_MODEL)
+        mock_chat_llamacpp.assert_called_once_with(TEST_LLAMACPP_MODEL, 'Help me')
+
+
+class TestCLIModeIntegration:
+    """Test complete CLI mode integration flows."""
+    
+    @patch('ai_server.server.subprocess.run')
+    @patch('ai_server.server.glob.glob')
+    def test_complete_cli_flow_with_real_model(self, mock_glob, mock_subprocess):
+        """Test complete CLI flow: model resolution → CLI execution."""
+        model_path = f'/data1/GGUF/{TEST_LLAMACPP_MODEL}/{TEST_LLAMACPP_MODEL}.gguf'
+        
+        mock_glob.return_value = [model_path]
+        mock_result = MagicMock()
+        mock_result.stdout = b'Complete integration test successful with DeepSeek V3!'
+        mock_subprocess.return_value = mock_result
+        
+        result = chat_with_model(TEST_LLAMACPP_MODEL, 'Integration test', llama_mode='cli')
+        
+        assert result == "Complete integration test successful with DeepSeek V3!"
+        # Verify glob called twice: once for availability check, once for CLI execution
+        assert mock_glob.call_count == 2
+        mock_subprocess.assert_called_once()
+    
+    @patch('ai_server.server.ollama.chat')
+    @patch('ai_server.server.glob.glob')
+    def test_complete_cli_fallback_flow_to_ollama(self, mock_glob, mock_ollama):
+        """Test complete CLI fallback flow: model not found → fallback to ollama."""
+        # Mock model not found in llama.cpp
+        mock_glob.return_value = []
+        
+        # Mock successful ollama response
+        mock_response = MagicMock()
+        mock_response.message.content = "Ollama CLI fallback integration test successful!"
+        mock_ollama.return_value = mock_response
+        
+        result = chat_with_model(TEST_OLLAMA_MODEL, 'Fallback test', llama_mode='cli')
+        
+        assert result == "Ollama CLI fallback integration test successful!"
+        mock_glob.assert_called_once_with(f'/data1/GGUF/{TEST_OLLAMA_MODEL}/*.gguf')
+        mock_ollama.assert_called_once() 
+        

--- a/test/test_cli_mode.py
+++ b/test/test_cli_mode.py
@@ -168,4 +168,3 @@ class TestCLIModeIntegration:
         assert result == "Ollama CLI fallback integration test successful!"
         mock_glob.assert_called_once_with(f'/data1/GGUF/{TEST_OLLAMA_MODEL}/*.gguf')
         mock_ollama.assert_called_once() 
-        

--- a/test/test_core.py
+++ b/test/test_core.py
@@ -1,0 +1,98 @@
+import pytest
+import os
+from unittest.mock import patch, MagicMock
+import sys
+
+os.environ.setdefault('REDIS_URL', 'redis://localhost:6379')
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..'))
+
+from ai_server.server import (
+    resolve_model_path,
+    is_llamacpp_available,
+    chat_with_ollama
+)
+
+# Test models
+TEST_LLAMACPP_MODEL = 'DeepSeek-V3-0324-UD-IQ2_XXS'
+TEST_OLLAMA_MODEL = 'deepseek-coder-v2:latest'
+
+
+class TestModelResolution:
+    """Test core model resolution functionality."""
+    
+    @patch('ai_server.server.glob.glob')
+    def test_resolve_model_path_found(self, mock_glob):
+        """Test model path resolution when model exists."""
+        model_path = f'/data1/GGUF/{TEST_LLAMACPP_MODEL}/{TEST_LLAMACPP_MODEL}.gguf'
+        mock_glob.return_value = [model_path]
+        
+        result = resolve_model_path(TEST_LLAMACPP_MODEL)
+        
+        assert result == model_path
+        mock_glob.assert_called_once_with(f'/data1/GGUF/{TEST_LLAMACPP_MODEL}/*.gguf')
+    
+    @patch('ai_server.server.glob.glob')
+    def test_resolve_model_path_not_found(self, mock_glob):
+        """Test model path resolution when model doesn't exist."""
+        mock_glob.return_value = []
+        
+        result = resolve_model_path('nonexistent-model')
+        
+        assert result is None
+    
+    @patch('ai_server.server.resolve_model_path')
+    def test_is_llamacpp_available_true(self, mock_resolve):
+        """Test model availability check when model exists."""
+        mock_resolve.return_value = f'/data1/GGUF/{TEST_LLAMACPP_MODEL}/{TEST_LLAMACPP_MODEL}.gguf'
+        
+        result = is_llamacpp_available(TEST_LLAMACPP_MODEL)
+        
+        assert result is True
+        mock_resolve.assert_called_once_with(TEST_LLAMACPP_MODEL)
+    
+    @patch('ai_server.server.resolve_model_path')
+    def test_is_llamacpp_available_false(self, mock_resolve):
+        """Test model availability check when model doesn't exist."""
+        mock_resolve.return_value = None
+        
+        result = is_llamacpp_available('nonexistent-model')
+        
+        assert result is False
+
+
+class TestOllamaCore:
+    """Test core ollama functionality used as fallback."""
+    
+    @patch('ai_server.server.ollama.chat')
+    def test_chat_with_ollama_success(self, mock_ollama_chat):
+        """Test successful chat with ollama."""
+        mock_response = MagicMock()
+        mock_response.message.content = "Hello! I'm DeepSeek Coder V2. I can help you with coding tasks."
+        mock_ollama_chat.return_value = mock_response
+        
+        result = chat_with_ollama(TEST_OLLAMA_MODEL, 'Help me write a Python function')
+        
+        assert result == "Hello! I'm DeepSeek Coder V2. I can help you with coding tasks."
+        mock_ollama_chat.assert_called_once_with(
+            model=TEST_OLLAMA_MODEL,
+            messages=[{'role': 'user', 'content': 'Help me write a Python function'}],
+            stream=False
+        )
+    
+    @patch('ai_server.server.ollama.chat')
+    def test_chat_with_ollama_service_unavailable(self, mock_ollama_chat):
+        """Test ollama chat when service is unavailable."""
+        mock_ollama_chat.side_effect = Exception("Ollama service is not running")
+        
+        with pytest.raises(Exception, match="Ollama service is not running"):
+            chat_with_ollama(TEST_OLLAMA_MODEL, 'Hello')
+    
+    @patch('ai_server.server.ollama.chat')
+    def test_chat_with_ollama_model_not_found(self, mock_ollama_chat):
+        """Test ollama chat when model is not found."""
+        mock_ollama_chat.side_effect = Exception("model 'nonexistent:latest' not found")
+        
+        with pytest.raises(Exception, match="model 'nonexistent:latest' not found"):
+            chat_with_ollama('nonexistent:latest', 'Hello') 
+            

--- a/test/test_core.py
+++ b/test/test_core.py
@@ -1,11 +1,8 @@
 import pytest
 import os
 from unittest.mock import patch, MagicMock
-import sys
 
 os.environ.setdefault('REDIS_URL', 'redis://localhost:6379')
-
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..'))
 
 from ai_server.server import (
     resolve_model_path,

--- a/test/test_core.py
+++ b/test/test_core.py
@@ -18,10 +18,22 @@ TEST_LLAMACPP_MODEL = 'DeepSeek-V3-0324-UD-IQ2_XXS'
 TEST_OLLAMA_MODEL = 'deepseek-coder-v2:latest'
 
 
+@pytest.fixture
+def mock_glob():
+    """Mock glob.glob for model discovery tests."""
+    with patch('ai_server.server.glob.glob') as mock:
+        yield mock
+
+@pytest.fixture
+def mock_ollama():
+    """Mock ollama.chat for ollama tests."""
+    with patch('ai_server.server.ollama.chat') as mock:
+        yield mock
+
+
 class TestModelResolution:
     """Test core model resolution functionality."""
     
-    @patch('ai_server.server.glob.glob')
     def test_resolve_model_path_found(self, mock_glob):
         """Test model path resolution when model exists."""
         model_path = f'/data1/GGUF/{TEST_LLAMACPP_MODEL}/{TEST_LLAMACPP_MODEL}.gguf'
@@ -32,7 +44,6 @@ class TestModelResolution:
         assert result == model_path
         mock_glob.assert_called_once_with(f'/data1/GGUF/{TEST_LLAMACPP_MODEL}/*.gguf')
     
-    @patch('ai_server.server.glob.glob')
     def test_resolve_model_path_not_found(self, mock_glob):
         """Test model path resolution when model doesn't exist."""
         mock_glob.return_value = []
@@ -41,57 +52,54 @@ class TestModelResolution:
         
         assert result is None
     
-    @patch('ai_server.server.resolve_model_path')
-    def test_is_llamacpp_available_true(self, mock_resolve):
+    def test_is_llamacpp_available_true(self):
         """Test model availability check when model exists."""
-        mock_resolve.return_value = f'/data1/GGUF/{TEST_LLAMACPP_MODEL}/{TEST_LLAMACPP_MODEL}.gguf'
-        
-        result = is_llamacpp_available(TEST_LLAMACPP_MODEL)
-        
-        assert result is True
-        mock_resolve.assert_called_once_with(TEST_LLAMACPP_MODEL)
+        with patch('ai_server.server.resolve_model_path') as mock_resolve:
+            mock_resolve.return_value = f'/data1/GGUF/{TEST_LLAMACPP_MODEL}/{TEST_LLAMACPP_MODEL}.gguf'
+            
+            result = is_llamacpp_available(TEST_LLAMACPP_MODEL)
+            
+            assert result is True
+            mock_resolve.assert_called_once_with(TEST_LLAMACPP_MODEL)
     
-    @patch('ai_server.server.resolve_model_path')
-    def test_is_llamacpp_available_false(self, mock_resolve):
+    def test_is_llamacpp_available_false(self):
         """Test model availability check when model doesn't exist."""
-        mock_resolve.return_value = None
-        
-        result = is_llamacpp_available('nonexistent-model')
-        
-        assert result is False
+        with patch('ai_server.server.resolve_model_path') as mock_resolve:
+            mock_resolve.return_value = None
+            
+            result = is_llamacpp_available('nonexistent-model')
+            
+            assert result is False
 
 
 class TestOllamaCore:
     """Test core ollama functionality used as fallback."""
     
-    @patch('ai_server.server.ollama.chat')
-    def test_chat_with_ollama_success(self, mock_ollama_chat):
+    def test_chat_with_ollama_success(self, mock_ollama):
         """Test successful chat with ollama."""
         mock_response = MagicMock()
         mock_response.message.content = "Hello! I'm DeepSeek Coder V2. I can help you with coding tasks."
-        mock_ollama_chat.return_value = mock_response
+        mock_ollama.return_value = mock_response
         
         result = chat_with_ollama(TEST_OLLAMA_MODEL, 'Help me write a Python function')
         
         assert result == "Hello! I'm DeepSeek Coder V2. I can help you with coding tasks."
-        mock_ollama_chat.assert_called_once_with(
+        mock_ollama.assert_called_once_with(
             model=TEST_OLLAMA_MODEL,
             messages=[{'role': 'user', 'content': 'Help me write a Python function'}],
             stream=False
         )
     
-    @patch('ai_server.server.ollama.chat')
-    def test_chat_with_ollama_service_unavailable(self, mock_ollama_chat):
+    def test_chat_with_ollama_service_unavailable(self, mock_ollama):
         """Test ollama chat when service is unavailable."""
-        mock_ollama_chat.side_effect = Exception("Ollama service is not running")
+        mock_ollama.side_effect = Exception("Ollama service is not running")
         
         with pytest.raises(Exception, match="Ollama service is not running"):
             chat_with_ollama(TEST_OLLAMA_MODEL, 'Hello')
     
-    @patch('ai_server.server.ollama.chat')
-    def test_chat_with_ollama_model_not_found(self, mock_ollama_chat):
+    def test_chat_with_ollama_model_not_found(self, mock_ollama):
         """Test ollama chat when model is not found."""
-        mock_ollama_chat.side_effect = Exception("model 'nonexistent:latest' not found")
+        mock_ollama.side_effect = Exception("model 'nonexistent:latest' not found")
         
         with pytest.raises(Exception, match="model 'nonexistent:latest' not found"):
             chat_with_ollama('nonexistent:latest', 'Hello') 

--- a/test/test_core.py
+++ b/test/test_core.py
@@ -103,4 +103,3 @@ class TestOllamaCore:
         
         with pytest.raises(Exception, match="model 'nonexistent:latest' not found"):
             chat_with_ollama('nonexistent:latest', 'Hello') 
-            

--- a/test/test_server_mode.py
+++ b/test/test_server_mode.py
@@ -16,55 +16,74 @@ TEST_LLAMACPP_MODEL = 'DeepSeek-V3-0324-UD-IQ2_XXS'
 TEST_OLLAMA_MODEL = 'deepseek-coder-v2:latest'
 
 
+@pytest.fixture
+def mock_requests_post():
+    """Mock requests.post for HTTP tests."""
+    with patch('ai_server.server.requests.post') as mock:
+        yield mock
+
+@pytest.fixture
+def mock_llama_server_url():
+    """Mock LLAMA_SERVER_URL for server tests."""
+    with patch('ai_server.server.LLAMA_SERVER_URL', 'http://localhost:8080'):
+        yield
+
+@pytest.fixture
+def mock_glob():
+    """Mock glob.glob for model discovery tests."""
+    with patch('ai_server.server.glob.glob') as mock:
+        yield mock
+
+@pytest.fixture
+def mock_ollama():
+    """Mock ollama.chat for fallback tests."""
+    with patch('ai_server.server.ollama.chat') as mock:
+        yield mock
+
+
 class TestLlamaServerHTTP:
     """Test llama.cpp server HTTP functionality."""
     
-    @patch('ai_server.server.requests.post')
-    @patch('ai_server.server.LLAMA_SERVER_URL', 'http://localhost:8080')
-    def test_chat_with_llama_server_http_success(self, mock_post):
+    def test_chat_with_llama_server_http_success(self, mock_requests_post, mock_llama_server_url):
         """Test successful HTTP chat with llama-server."""
         mock_response = MagicMock()
         mock_response.status_code = 200
         mock_response.json.return_value = {
             'choices': [{'message': {'content': 'Server response from DeepSeek V3'}}]
         }
-        mock_post.return_value = mock_response
+        mock_requests_post.return_value = mock_response
         
         result = chat_with_llama_server_http(TEST_LLAMACPP_MODEL, 'Hello from server')
         
         assert result == "Server response from DeepSeek V3"
         
         # Verify correct API call
-        args, kwargs = mock_post.call_args
+        args, kwargs = mock_requests_post.call_args
         assert args[0] == 'http://localhost:8080/v1/chat/completions'
         assert kwargs['json']['model'] == TEST_LLAMACPP_MODEL
         assert kwargs['json']['messages'][0]['content'] == 'Hello from server'
     
-    @patch('ai_server.server.LLAMA_SERVER_URL', None)
     def test_chat_with_llama_server_http_no_url(self):
         """Test HTTP chat when LLAMA_SERVER_URL is not set."""
-        with pytest.raises(Exception, match="LLAMA_SERVER_URL environment variable not set"):
-            chat_with_llama_server_http(TEST_LLAMACPP_MODEL, 'Hello')
+        with patch('ai_server.server.LLAMA_SERVER_URL', None):
+            with pytest.raises(Exception, match="LLAMA_SERVER_URL environment variable not set"):
+                chat_with_llama_server_http(TEST_LLAMACPP_MODEL, 'Hello')
     
-    @patch('ai_server.server.requests.post')
-    @patch('ai_server.server.LLAMA_SERVER_URL', 'http://localhost:8080')
-    def test_chat_with_llama_server_http_error_response(self, mock_post):
+    def test_chat_with_llama_server_http_error_response(self, mock_requests_post, mock_llama_server_url):
         """Test HTTP chat when server returns error."""
         mock_response = MagicMock()
         mock_response.status_code = 500
-        mock_post.return_value = mock_response
+        mock_requests_post.return_value = mock_response
         
         with pytest.raises(Exception, match="Llama-server HTTP error"):
             chat_with_llama_server_http(TEST_LLAMACPP_MODEL, 'Hello')
     
-    @patch('ai_server.server.requests.post')
-    @patch('ai_server.server.LLAMA_SERVER_URL', 'http://localhost:8080')
-    def test_chat_with_llama_server_http_invalid_response_format(self, mock_post):
+    def test_chat_with_llama_server_http_invalid_response_format(self, mock_requests_post, mock_llama_server_url):
         """Test HTTP chat when server returns invalid response format."""
         mock_response = MagicMock()
         mock_response.status_code = 200
         mock_response.json.return_value = {'error': 'Invalid request'}  # Missing choices
-        mock_post.return_value = mock_response
+        mock_requests_post.return_value = mock_response
         
         with pytest.raises(Exception, match="Invalid response format from llama-server"):
             chat_with_llama_server_http(TEST_LLAMACPP_MODEL, 'Hello')
@@ -73,47 +92,51 @@ class TestLlamaServerHTTP:
 class TestServerModeRouting:
     """Test server mode routing and fallback logic."""
     
-    @patch('ai_server.server.chat_with_llama_server_http')
-    @patch('ai_server.server.is_llamacpp_available')
-    @patch('ai_server.server.LLAMA_SERVER_URL', 'http://localhost:8080')
-    def test_server_mode_uses_llamacpp_when_available(self, mock_available, mock_chat_server):
+    @pytest.fixture(autouse=True)
+    def setup_routing_mocks(self):
+        """Set up common mocks for routing tests."""
+        with patch('ai_server.server.chat_with_llama_server_http') as mock_chat_server, \
+             patch('ai_server.server.is_llamacpp_available') as mock_available, \
+             patch('ai_server.server.chat_with_ollama') as mock_chat_ollama, \
+             patch('ai_server.server.LLAMA_SERVER_URL', 'http://localhost:8080'):
+            self.mock_chat_server = mock_chat_server
+            self.mock_available = mock_available
+            self.mock_chat_ollama = mock_chat_ollama
+            yield
+    
+    def test_server_mode_uses_llamacpp_when_available(self):
         """Test server mode routes to llama-server when model is available."""
-        mock_available.return_value = True
-        mock_chat_server.return_value = "Server response from DeepSeek V3"
+        self.mock_available.return_value = True
+        self.mock_chat_server.return_value = "Server response from DeepSeek V3"
         
         result = chat_with_model(TEST_LLAMACPP_MODEL, 'Explain code', llama_mode='server')
         
         assert result == "Server response from DeepSeek V3"
-        mock_available.assert_called_once_with(TEST_LLAMACPP_MODEL)
-        mock_chat_server.assert_called_once_with(TEST_LLAMACPP_MODEL, 'Explain code')
+        self.mock_available.assert_called_once_with(TEST_LLAMACPP_MODEL)
+        self.mock_chat_server.assert_called_once_with(TEST_LLAMACPP_MODEL, 'Explain code')
     
-    @patch('ai_server.server.chat_with_ollama')
-    @patch('ai_server.server.is_llamacpp_available')
-    @patch('ai_server.server.LLAMA_SERVER_URL', 'http://localhost:8080')
-    def test_server_mode_fallback_to_ollama_when_unavailable(self, mock_available, mock_chat_ollama):
+    def test_server_mode_fallback_to_ollama_when_unavailable(self):
         """Test server mode falls back to ollama when model not available in llama.cpp."""
-        mock_available.return_value = False
-        mock_chat_ollama.return_value = "Ollama fallback response"
+        self.mock_available.return_value = False
+        self.mock_chat_ollama.return_value = "Ollama fallback response"
         
         result = chat_with_model(TEST_OLLAMA_MODEL, 'Debug code', llama_mode='server')
         
         assert result == "Ollama fallback response"
-        mock_available.assert_called_once_with(TEST_OLLAMA_MODEL)
-        mock_chat_ollama.assert_called_once_with(TEST_OLLAMA_MODEL, 'Debug code')
+        self.mock_available.assert_called_once_with(TEST_OLLAMA_MODEL)
+        self.mock_chat_ollama.assert_called_once_with(TEST_OLLAMA_MODEL, 'Debug code')
     
-    @patch('ai_server.server.is_llamacpp_available')
-    @patch('ai_server.server.LLAMA_SERVER_URL', None)
-    def test_server_mode_requires_server_url(self, mock_available):
+    def test_server_mode_requires_server_url(self):
         """Test server mode requires LLAMA_SERVER_URL to be set."""
-        mock_available.return_value = True
-        
-        with pytest.raises(Exception, match="LLAMA_SERVER_URL environment variable not set"):
-            chat_with_model(TEST_LLAMACPP_MODEL, 'Hello', llama_mode='server')
+        with patch('ai_server.server.LLAMA_SERVER_URL', None):
+            self.mock_available.return_value = True
+            
+            with pytest.raises(Exception, match="LLAMA_SERVER_URL environment variable not set"):
+                chat_with_model(TEST_LLAMACPP_MODEL, 'Hello', llama_mode='server')
     
-    @patch('ai_server.server.is_llamacpp_available')
-    def test_invalid_llama_mode_raises_error(self, mock_available):
+    def test_invalid_llama_mode_raises_error(self):
         """Test that invalid llama_mode raises ValueError."""
-        mock_available.return_value = True
+        self.mock_available.return_value = True
         
         with pytest.raises(ValueError, match="Invalid llama_mode: 'invalid'"):
             chat_with_model(TEST_LLAMACPP_MODEL, 'Hello', llama_mode='invalid')
@@ -122,10 +145,7 @@ class TestServerModeRouting:
 class TestServerModeIntegration:
     """Test complete server mode integration flows."""
     
-    @patch('ai_server.server.requests.post')
-    @patch('ai_server.server.glob.glob')
-    @patch('ai_server.server.LLAMA_SERVER_URL', 'http://localhost:8080')
-    def test_complete_server_flow_with_real_model(self, mock_glob, mock_requests):
+    def test_complete_server_flow_with_real_model(self, mock_glob, mock_requests_post, mock_llama_server_url):
         """Test complete server flow: model resolution → HTTP API call."""
         model_path = f'/data1/GGUF/{TEST_LLAMACPP_MODEL}/{TEST_LLAMACPP_MODEL}.gguf'
         
@@ -138,19 +158,16 @@ class TestServerModeIntegration:
         mock_response.json.return_value = {
             'choices': [{'message': {'content': 'Server integration test successful!'}}]
         }
-        mock_requests.return_value = mock_response
+        mock_requests_post.return_value = mock_response
         
         result = chat_with_model(TEST_LLAMACPP_MODEL, 'Integration test', llama_mode='server')
         
         assert result == "Server integration test successful!"
         # In server mode, glob.glob only called once for is_llamacpp_available
         mock_glob.assert_called_once_with(f'/data1/GGUF/{TEST_LLAMACPP_MODEL}/*.gguf')
-        mock_requests.assert_called_once()
+        mock_requests_post.assert_called_once()
     
-    @patch('ai_server.server.ollama.chat')
-    @patch('ai_server.server.glob.glob')
-    @patch('ai_server.server.LLAMA_SERVER_URL', 'http://localhost:8080')
-    def test_complete_server_fallback_flow_to_ollama(self, mock_glob, mock_ollama):
+    def test_complete_server_fallback_flow_to_ollama(self, mock_glob, mock_ollama, mock_llama_server_url):
         """Test complete server fallback flow: model not found → fallback to ollama."""
         # Mock model not found in llama.cpp
         mock_glob.return_value = []

--- a/test/test_server_mode.py
+++ b/test/test_server_mode.py
@@ -1,0 +1,168 @@
+import pytest
+import os
+from unittest.mock import patch, MagicMock
+import sys
+
+os.environ.setdefault('REDIS_URL', 'redis://localhost:6379')
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..'))
+
+from ai_server.server import (
+    chat_with_llama_server_http,
+    chat_with_model
+)
+
+# Test models
+TEST_LLAMACPP_MODEL = 'DeepSeek-V3-0324-UD-IQ2_XXS'
+TEST_OLLAMA_MODEL = 'deepseek-coder-v2:latest'
+
+
+class TestLlamaServerHTTP:
+    """Test llama.cpp server HTTP functionality."""
+    
+    @patch('ai_server.server.requests.post')
+    @patch('ai_server.server.LLAMA_SERVER_URL', 'http://localhost:8080')
+    def test_chat_with_llama_server_http_success(self, mock_post):
+        """Test successful HTTP chat with llama-server."""
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {
+            'choices': [{'message': {'content': 'Server response from DeepSeek V3'}}]
+        }
+        mock_post.return_value = mock_response
+        
+        result = chat_with_llama_server_http(TEST_LLAMACPP_MODEL, 'Hello from server')
+        
+        assert result == "Server response from DeepSeek V3"
+        
+        # Verify correct API call
+        args, kwargs = mock_post.call_args
+        assert args[0] == 'http://localhost:8080/v1/chat/completions'
+        assert kwargs['json']['model'] == TEST_LLAMACPP_MODEL
+        assert kwargs['json']['messages'][0]['content'] == 'Hello from server'
+    
+    @patch('ai_server.server.LLAMA_SERVER_URL', None)
+    def test_chat_with_llama_server_http_no_url(self):
+        """Test HTTP chat when LLAMA_SERVER_URL is not set."""
+        with pytest.raises(Exception, match="LLAMA_SERVER_URL environment variable not set"):
+            chat_with_llama_server_http(TEST_LLAMACPP_MODEL, 'Hello')
+    
+    @patch('ai_server.server.requests.post')
+    @patch('ai_server.server.LLAMA_SERVER_URL', 'http://localhost:8080')
+    def test_chat_with_llama_server_http_error_response(self, mock_post):
+        """Test HTTP chat when server returns error."""
+        mock_response = MagicMock()
+        mock_response.status_code = 500
+        mock_post.return_value = mock_response
+        
+        with pytest.raises(Exception, match="Llama-server HTTP error"):
+            chat_with_llama_server_http(TEST_LLAMACPP_MODEL, 'Hello')
+    
+    @patch('ai_server.server.requests.post')
+    @patch('ai_server.server.LLAMA_SERVER_URL', 'http://localhost:8080')
+    def test_chat_with_llama_server_http_invalid_response_format(self, mock_post):
+        """Test HTTP chat when server returns invalid response format."""
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {'error': 'Invalid request'}  # Missing choices
+        mock_post.return_value = mock_response
+        
+        with pytest.raises(Exception, match="Invalid response format from llama-server"):
+            chat_with_llama_server_http(TEST_LLAMACPP_MODEL, 'Hello')
+
+
+class TestServerModeRouting:
+    """Test server mode routing and fallback logic."""
+    
+    @patch('ai_server.server.chat_with_llama_server_http')
+    @patch('ai_server.server.is_llamacpp_available')
+    @patch('ai_server.server.LLAMA_SERVER_URL', 'http://localhost:8080')
+    def test_server_mode_uses_llamacpp_when_available(self, mock_available, mock_chat_server):
+        """Test server mode routes to llama-server when model is available."""
+        mock_available.return_value = True
+        mock_chat_server.return_value = "Server response from DeepSeek V3"
+        
+        result = chat_with_model(TEST_LLAMACPP_MODEL, 'Explain code', llama_mode='server')
+        
+        assert result == "Server response from DeepSeek V3"
+        mock_available.assert_called_once_with(TEST_LLAMACPP_MODEL)
+        mock_chat_server.assert_called_once_with(TEST_LLAMACPP_MODEL, 'Explain code')
+    
+    @patch('ai_server.server.chat_with_ollama')
+    @patch('ai_server.server.is_llamacpp_available')
+    @patch('ai_server.server.LLAMA_SERVER_URL', 'http://localhost:8080')
+    def test_server_mode_fallback_to_ollama_when_unavailable(self, mock_available, mock_chat_ollama):
+        """Test server mode falls back to ollama when model not available in llama.cpp."""
+        mock_available.return_value = False
+        mock_chat_ollama.return_value = "Ollama fallback response"
+        
+        result = chat_with_model(TEST_OLLAMA_MODEL, 'Debug code', llama_mode='server')
+        
+        assert result == "Ollama fallback response"
+        mock_available.assert_called_once_with(TEST_OLLAMA_MODEL)
+        mock_chat_ollama.assert_called_once_with(TEST_OLLAMA_MODEL, 'Debug code')
+    
+    @patch('ai_server.server.is_llamacpp_available')
+    @patch('ai_server.server.LLAMA_SERVER_URL', None)
+    def test_server_mode_requires_server_url(self, mock_available):
+        """Test server mode requires LLAMA_SERVER_URL to be set."""
+        mock_available.return_value = True
+        
+        with pytest.raises(Exception, match="LLAMA_SERVER_URL environment variable not set"):
+            chat_with_model(TEST_LLAMACPP_MODEL, 'Hello', llama_mode='server')
+    
+    @patch('ai_server.server.is_llamacpp_available')
+    def test_invalid_llama_mode_raises_error(self, mock_available):
+        """Test that invalid llama_mode raises ValueError."""
+        mock_available.return_value = True
+        
+        with pytest.raises(ValueError, match="Invalid llama_mode: 'invalid'"):
+            chat_with_model(TEST_LLAMACPP_MODEL, 'Hello', llama_mode='invalid')
+
+
+class TestServerModeIntegration:
+    """Test complete server mode integration flows."""
+    
+    @patch('ai_server.server.requests.post')
+    @patch('ai_server.server.glob.glob')
+    @patch('ai_server.server.LLAMA_SERVER_URL', 'http://localhost:8080')
+    def test_complete_server_flow_with_real_model(self, mock_glob, mock_requests):
+        """Test complete server flow: model resolution → HTTP API call."""
+        model_path = f'/data1/GGUF/{TEST_LLAMACPP_MODEL}/{TEST_LLAMACPP_MODEL}.gguf'
+        
+        # Mock model found (only checked once for availability in server mode)
+        mock_glob.return_value = [model_path]
+        
+        # Mock successful HTTP response
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {
+            'choices': [{'message': {'content': 'Server integration test successful!'}}]
+        }
+        mock_requests.return_value = mock_response
+        
+        result = chat_with_model(TEST_LLAMACPP_MODEL, 'Integration test', llama_mode='server')
+        
+        assert result == "Server integration test successful!"
+        # In server mode, glob.glob only called once for is_llamacpp_available
+        mock_glob.assert_called_once_with(f'/data1/GGUF/{TEST_LLAMACPP_MODEL}/*.gguf')
+        mock_requests.assert_called_once()
+    
+    @patch('ai_server.server.ollama.chat')
+    @patch('ai_server.server.glob.glob')
+    @patch('ai_server.server.LLAMA_SERVER_URL', 'http://localhost:8080')
+    def test_complete_server_fallback_flow_to_ollama(self, mock_glob, mock_ollama):
+        """Test complete server fallback flow: model not found → fallback to ollama."""
+        # Mock model not found in llama.cpp
+        mock_glob.return_value = []
+        
+        # Mock successful ollama response
+        mock_response = MagicMock()
+        mock_response.message.content = "Ollama server fallback integration test successful!"
+        mock_ollama.return_value = mock_response
+        
+        result = chat_with_model(TEST_OLLAMA_MODEL, 'Fallback test', llama_mode='server')
+        
+        assert result == "Ollama server fallback integration test successful!"
+        mock_glob.assert_called_once_with(f'/data1/GGUF/{TEST_OLLAMA_MODEL}/*.gguf')
+        mock_ollama.assert_called_once() 
+        

--- a/test/test_server_mode.py
+++ b/test/test_server_mode.py
@@ -1,10 +1,8 @@
 import pytest
 import os
 from unittest.mock import patch, MagicMock
-import sys
 
 os.environ.setdefault('REDIS_URL', 'redis://localhost:6379')
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..'))
 
 from ai_server.server import (
     chat_with_llama_server_http,

--- a/test/test_server_mode.py
+++ b/test/test_server_mode.py
@@ -182,4 +182,3 @@ class TestServerModeIntegration:
         assert result == "Ollama server fallback integration test successful!"
         mock_glob.assert_called_once_with(f'/data1/GGUF/{TEST_OLLAMA_MODEL}/*.gguf')
         mock_ollama.assert_called_once() 
-        


### PR DESCRIPTION
`test_core.py`:
- Model path resolution with glob pattern matching
- Model availability checking for llama.cpp models
- Core ollama chat functionality used as fallback

`test_cli_mode.py`:
- CLI mode routing logic
- CLI mode fallback to ollama when model unavailable

`test_server_mode.py`:
- Server mode routing logic
- Server mode fallback to ollama when model unavailable
